### PR TITLE
Moved to JRE download

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git_credential_manager_jre_major_version: '8'
 git_credential_manager_jre_version: 'jdk8u212-b03_openj9-0.14.0'
 
 # The SHA256 of the JRE
-git_credential_manager_jre_sha256sum: '4aa8fdb3916816788c516423236bef68a05a694cbd44fa14c4f8f5b76891aa4c'
+git_credential_manager_jre_sha256sum: '61abbd6b4ab093adb5a0ed6ec89a54123396d8512a44168f7e01d3e7b1fdd07b'
 
 # Base installation directory the Git Credential Manager
 git_credential_manager_install_dir: '/opt/git-credential-manager/{{ git_credential_manager_version }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ git_credential_manager_jre_major_version: '8'
 git_credential_manager_jre_version: 'jdk8u212-b03_openj9-0.14.0'
 
 # The SHA256 of the JRE
-git_credential_manager_jre_sha256sum: '4aa8fdb3916816788c516423236bef68a05a694cbd44fa14c4f8f5b76891aa4c'
+git_credential_manager_jre_sha256sum: '61abbd6b4ab093adb5a0ed6ec89a54123396d8512a44168f7e01d3e7b1fdd07b'
 
 # Base installation directory the Git Credential Manager
 git_credential_manager_install_dir: '/opt/git-credential-manager/{{ git_credential_manager_version }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: download JRE
   get_url:
-    url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk{{ git_credential_manager_jre_major_version }}?openjdk_impl=openj9&heap_size=normal&os={{ git_credential_manager_os }}&arch={{ git_credential_manager_architecture }}&release={{ git_credential_manager_jre_version }}&type=jdk'
+    url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk{{ git_credential_manager_jre_major_version }}?openjdk_impl=openj9&heap_size=normal&os={{ git_credential_manager_os }}&arch={{ git_credential_manager_architecture }}&release={{ git_credential_manager_jre_version }}&type=jre'
     dest: '{{ git_credential_manager_download_dir }}/{{ git_credential_manager_jre_filename }}'
     sha256sum: '{{ git_credential_manager_jre_sha256sum }}'
     force: no
@@ -49,27 +49,21 @@
   with_items:
     - '{{ git_credential_manager_install_dir }}'
     - '{{ git_credential_manager_install_dir }}/bin'
+    - '{{ git_credential_manager_install_dir }}/jre'
     - '{{ git_credential_manager_install_dir }}/libexec'
 
 - name: install JRE
   become: yes
-  # TODO replace with unarchive module when JRE releases of OpenJ9 are available
-  command: >
-    tar --extract --gunzip --no-same-owner
-        --file '{{ git_credential_manager_download_dir }}/{{ git_credential_manager_jre_filename }}'
-        --strip-components=1 --wildcards '*/jre'
-  args:
-    chdir: '{{ git_credential_manager_install_dir }}'
-    creates: '{{ git_credential_manager_install_dir }}/jre'
-    # We need to use tar directly because the unarchive module doesn't support partial extraction
-    warn: no
-
-# The OpenJ9 package appears to be missing read permissions in /lib & /lib/ext
-- name: set JRE file permissions
-  file:
-    path: '{{ git_credential_manager_install_dir }}/jre'
-    recurse: yes
-    mode: 'go+r'
+  unarchive:
+    src: '{{ git_credential_manager_download_dir }}/{{ git_credential_manager_jre_filename }}'
+    remote_src: yes
+    dest: '{{ git_credential_manager_install_dir }}/jre'
+    extra_opts:
+      - --strip-components=1
+    owner: root
+    group: root
+    # The OpenJ9 package appears to be missing read permissions in /lib & /lib/ext
+    mode: 'go-w,go+r'
 
 - name: install Git Credential Manager
   become: yes


### PR DESCRIPTION
As JRE downloads weren't available we were downloading the JDK and extracting the JRE. Now JRE downloads are available we can use the smaller download.