### PR TITLE
Upgraded Git Credential Manager to version 2.0.696

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ The following variables will change the behavior of this role:
 
 ```yaml
 # Git Credential Manager version number
-git_credential_manager_version: '2.0.632'
-
-# Git Credential Manager build number
-git_credential_manager_build: '34631'
+git_credential_manager_version: '2.0.696'
 
 # The SHA256 of the Git Credential Manager JAR
-git_credential_manager_redis_sha256sum: '41d116b3e4b62099a41d7de21f815724cefa8d386af767695da8ef0ac8b4aa33'
+git_credential_manager_redis_sha256sum: 'caba73101f80c1a789225730d0d1b82941c31707cef6a55fb3cb3caada68d234'
 
 # The credential store to use
 git_credential_manager_credential_store: 'secretservice'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,9 @@
 ---
 # Git Credential Manager version number
-git_credential_manager_version: '2.0.632'
-
-# Git Credential Manager build number
-git_credential_manager_build: '34631'
+git_credential_manager_version: '2.0.696'
 
 # The SHA256 of the Git Credential Manager JAR
-git_credential_manager_redis_sha256sum: '41d116b3e4b62099a41d7de21f815724cefa8d386af767695da8ef0ac8b4aa33'
+git_credential_manager_redis_sha256sum: 'caba73101f80c1a789225730d0d1b82941c31707cef6a55fb3cb3caada68d234'
 
 # The credential store to use
 git_credential_manager_credential_store: 'secretservice'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 git_credential_manager_mirror: 'https://github.com/GitCredentialManager/git-credential-manager/releases/download/v{{ git_credential_manager_version }}'
 
 # File name of the Git Credential Manager redistributable
-git_credential_manager_redis_filename: 'gcmcore-linux_amd64.{{ git_credential_manager_version }}.{{ git_credential_manager_build }}.deb'
+git_credential_manager_redis_filename: 'gcmcore-linux_amd64.{{ git_credential_manager_version }}.deb'
 
 # The credential helper to set in the git config
 git_credential_manager_credential_helper: '/usr/local/share/gcm-core/git-credential-manager-core'


### PR DESCRIPTION
Keeping up with the latest changes.